### PR TITLE
Add `--git` option

### DIFF
--- a/gem_generator.gemspec
+++ b/gem_generator.gemspec
@@ -46,11 +46,13 @@ Gem::Specification.new do |spec|
 
 	spec.add_development_dependency 'pry-byebug', '~> 3.9'
 
-	spec.add_development_dependency 'bundler', '~> 2.0'
-	spec.add_development_dependency 'gem_toys', '~> 0.9.0'
-	spec.add_development_dependency 'toys', '~> 0.12.0'
+	spec.add_development_dependency 'inifile', '~> 3.0'
 
+	spec.add_development_dependency 'bundler', '~> 2.0'
 	spec.add_development_dependency 'bundler-audit', '~> 0.9.0'
+
+	spec.add_development_dependency 'gem_toys', '~> 0.10.0'
+	spec.add_development_dependency 'toys', '~> 0.12.0'
 
 	spec.add_development_dependency 'ffaker', '~> 2.19'
 	spec.add_development_dependency 'rspec', '~> 3.9'

--- a/lib/gem_generator/render_variables.rb
+++ b/lib/gem_generator/render_variables.rb
@@ -20,6 +20,9 @@ module GemGenerator
 			@namespace_option = namespace_option
 			@indentation = indentation
 			@summary = summary
+
+			## Call to be sure that this is checked before author fields
+			github_namespace
 		end
 
 		## `public :binding` and `send :binding` return caller binding

--- a/spec/gem_generator/command_spec.rb
+++ b/spec/gem_generator/command_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'gorilla_patch/deep_merge'
+require 'inifile'
 
 describe GemGenerator::Command do
 	using GorillaPatch::DeepMerge
@@ -85,7 +86,6 @@ describe GemGenerator::Command do
 			end
 
 			context 'with template parameter' do
-				let(:template) { "#{__dir__}/../support/example_template" }
 				let(:args) { [*super(), template] }
 
 				let(:gem_summary) { 'Foo bar gem' }
@@ -110,57 +110,19 @@ describe GemGenerator::Command do
 					FileUtils.rm_r gem_name if Dir.exist? gem_name
 				end
 
-				shared_context 'with changing git user config' do |git_property|
-					before do
-						value = send("temp_git_#{git_property}")
-						system "git config user.#{git_property} \"#{value}\""
-					end
-
-					after do
-						system "git config --unset user.#{git_property}"
-					end
-				end
-
-				shared_examples 'correct behavior with all data' do
-					describe 'output' do
-						let(:expected_output_start) do
-							## There is allowed prompt
-							<<~OUTPUT
-								Please, write a summary for the gem:
-
-								Thank you! You can write more detailed description later for `spec.description` and `README.md`.
-
-								Copying files...
-								Renaming files...
-								Rendering files...
-								Installing dependencies...
-								Initializing git...
-							OUTPUT
-						end
-
-						let(:expected_output_end) do
-							<<~OUTPUT
-								Done.
-								To checkout into a new directory:
-									cd #{gem_name}
-							OUTPUT
-						end
-
-						specify do
-							expect { run }.to output(
-								a_string_starting_with(expected_output_start)
-									.and(ending_with(expected_output_end))
-							).to_stdout_from_any_process.and not_output.to_stderr_from_any_process
-						end
-					end
-
-					describe 'system calls' do
-						include_context 'with supressing regular output'
-
+				shared_examples 'correct behavior with template' do
+					shared_context 'with changing git user config' do |git_property|
 						before do
-							run
+							value = send("temp_git_#{git_property}")
+							system "git config user.#{git_property} \"#{value}\""
 						end
 
+						after do
+							system "git config --unset user.#{git_property}"
+						end
+					end
+
+					shared_examples 'common correct system calls with all data' do
 						specify do
 							expect(command_instance).to have_received(:system).with('git init').once
 						end
@@ -168,33 +130,9 @@ describe GemGenerator::Command do
 						specify do
 							expect(command_instance).to have_received(:system).with('bundle update').once
 						end
-
-						context 'without `package.json` file' do
-							specify do
-								expect(command_instance).not_to have_received(:system).with('npm install')
-							end
-						end
-
-						context 'with `package.json` file' do
-							around do |example|
-								if File.exist? "#{template}/package.json"
-									raise 'Template should not contain `package.json` file'
-								end
-
-								FileUtils.touch "#{template}/package.json"
-								example.run
-								FileUtils.rm "#{template}/package.json"
-							end
-
-							specify do
-								expect(command_instance).to have_received(:system).with('npm install').once
-							end
-						end
 					end
 
-					describe 'files' do
-						include_context 'with supressing regular output'
-
+					shared_examples 'common correct files with all data' do
 						describe 'gem_name.gemspec.erb' do
 							subject(:file_content) do
 								File.read(File.join(Dir.pwd, gem_name, "#{gem_name}.gemspec"))
@@ -256,7 +194,7 @@ describe GemGenerator::Command do
 							let(:expected_lines) do
 								[
 									'# Changelog',
-									'## main (unreleased)',
+									'## Unreleased',
 									'*   Initial release.'
 								]
 							end
@@ -267,8 +205,8 @@ describe GemGenerator::Command do
 						end
 
 						describe '.editorconfig' do
-							subject(:file_content) do
-								File.read(File.join(Dir.pwd, gem_name, '.editorconfig'))
+							subject(:ini_file) do
+								IniFile.load(File.join(Dir.pwd, gem_name, '.editorconfig')).to_h
 							end
 
 							before do
@@ -276,24 +214,25 @@ describe GemGenerator::Command do
 							end
 
 							context 'with default indentation (tabs)' do
-								let(:expected_lines) do
-									[
-										'[*]',
-										'indent_style = tab',
-										'indent_size = 2'
-									]
+								let(:expected_values) do
+									a_hash_including(
+										'*' => a_hash_including(
+											'indent_style' => 'tab',
+											'indent_size' => 2
+										)
+									)
 								end
 
-								let(:not_expected_lines) do
-									[
-										'indent_style = space'
-									]
+								let(:not_expected_values) do
+									a_hash_including(
+										'*' => a_hash_including(
+											'indent_style' => 'space'
+										)
+									)
 								end
 
 								it do
-									expect(file_content).to include_lines(expected_lines).and(
-										not_include_lines(not_expected_lines)
-									)
+									expect(ini_file).to match(expected_values).and not_match(not_expected_values)
 								end
 
 								describe '.gemspec indentation' do
@@ -311,24 +250,25 @@ describe GemGenerator::Command do
 									[*super(), '--indentation=spaces']
 								end
 
-								let(:expected_lines) do
-									[
-										'[*]',
-										'indent_style = space',
-										'indent_size = 2'
-									]
+								let(:expected_values) do
+									a_hash_including(
+										'*' => a_hash_including(
+											'indent_style' => 'space',
+											'indent_size' => 2
+										)
+									)
 								end
 
-								let(:not_expected_lines) do
-									[
-										'indent_style = tab'
-									]
+								let(:not_expected_values) do
+									a_hash_including(
+										'*' => a_hash_including(
+											'indent_style' => 'tab'
+										)
+									)
 								end
 
 								it do
-									expect(file_content).to include_lines(expected_lines).and(
-										not_include_lines(not_expected_lines)
-									)
+									expect(ini_file).to match(expected_values).and not_match(not_expected_values)
 								end
 
 								describe '.gemspec indentation' do
@@ -341,6 +281,429 @@ describe GemGenerator::Command do
 								end
 							end
 						end
+					end
+
+					shared_examples 'common correct behavior with all data' do
+						describe 'output' do
+							let(:expected_output_start) do
+								## There is allowed prompt
+								<<~OUTPUT
+									Please, write a summary for the gem:
+
+									Thank you! You can write more detailed description later for `spec.description` and `README.md`.
+
+									Copying files...
+									Renaming files...
+									Rendering files...
+									Installing dependencies...
+									Initializing git...
+								OUTPUT
+							end
+
+							let(:expected_output_end) do
+								<<~OUTPUT
+									Done.
+									To checkout into a new directory:
+										cd #{gem_name}
+								OUTPUT
+							end
+
+							specify do
+								expect { run }.to output(
+									a_string_starting_with(expected_output_start)
+										.and(ending_with(expected_output_end))
+								).to_stdout_from_any_process.and not_output.to_stderr_from_any_process
+							end
+						end
+
+						describe 'system calls' do
+							include_context 'with supressing regular output'
+
+							before do
+								run
+							end
+
+							include_examples 'correct system calls with all data'
+						end
+
+						describe 'files' do
+							include_context 'with supressing regular output'
+
+							include_examples 'correct files with all data'
+						end
+					end
+
+					shared_examples 'correct behavior without author name' do
+						include_context 'with changing git user config', :name do
+							let(:temp_git_name) { nil }
+						end
+
+						describe 'output' do
+							let(:expected_output_start) do
+								## There is allowed prompt
+								<<~OUTPUT
+									Please, write a summary for the gem:
+
+									Thank you! You can write more detailed description later for `spec.description` and `README.md`.
+
+									Copying files...
+								OUTPUT
+							end
+
+							## There is some dependencies installation output
+
+							let(:non_expected_output_end) do
+								<<~OUTPUT
+									Done.
+									To checkout into a new directory:
+										cd #{gem_name}
+								OUTPUT
+							end
+
+							specify do
+								expect { run }.to raise_error(SystemExit).and output(
+									a_string_starting_with(expected_output_start)
+										.and(not_ending_with(non_expected_output_end))
+								).to_stdout.and output(<<~OUTPUT).to_stderr
+									You have to specify project's author name.
+									You can use `git config user.name "My Name"`, or create a configuration file.
+									Check the README.
+								OUTPUT
+							end
+						end
+
+						include_examples 'target directory does not exist'
+					end
+
+					shared_examples 'correct behavior without author email' do
+						include_context 'with changing git user config', :email do
+							let(:temp_git_email) { nil }
+						end
+
+						context 'with author name from git' do
+							include_context 'with changing git user config', :name do
+								let(:temp_git_name) { FFaker::Name.name }
+							end
+
+							describe 'output' do
+								let(:expected_output_start) do
+									## There is allowed prompt
+									<<~OUTPUT
+										Please, write a summary for the gem:
+
+										Thank you! You can write more detailed description later for `spec.description` and `README.md`.
+
+										Copying files...
+									OUTPUT
+								end
+
+								## There is some dependencies installation output
+
+								let(:non_expected_output_end) do
+									<<~OUTPUT
+										Done.
+										To checkout into a new directory:
+											cd #{gem_name}
+									OUTPUT
+								end
+
+								specify do
+									expect { run }.to raise_error(SystemExit).and output(
+										a_string_starting_with(expected_output_start)
+											.and(not_ending_with(non_expected_output_end))
+									).to_stdout.and output(<<~OUTPUT).to_stderr
+										You have to specify project's author email.
+										You can use `git config user.email "my.email@example.com"`, or create a configuration file.
+										Check the README.
+									OUTPUT
+								end
+							end
+
+							include_examples 'target directory does not exist'
+						end
+					end
+
+					shared_examples 'correct behavior without namespace' do
+						describe 'output' do
+							let(:expected_output_start) do
+								## There is allowed prompt
+								<<~OUTPUT
+									Please, write a summary for the gem:
+
+									Thank you! You can write more detailed description later for `spec.description` and `README.md`.
+
+									Copying files...
+								OUTPUT
+							end
+
+							## There is some dependencies installation output
+
+							let(:non_expected_output_end) do
+								<<~OUTPUT
+									Done.
+									To checkout into a new directory:
+										cd #{gem_name}
+								OUTPUT
+							end
+
+							specify do
+								expect { run }.to raise_error(SystemExit).and output(
+									a_string_starting_with(expected_output_start)
+										.and(not_ending_with(non_expected_output_end))
+								).to_stdout.and output(<<~OUTPUT).to_stderr
+									You have to specify project's namespace on GitHub.
+									You can use `--namespace` option, or create a configuration file.
+									Check the README.
+								OUTPUT
+							end
+						end
+
+						include_examples 'target directory does not exist'
+					end
+
+					context 'without config file' do
+						before do
+							# render_variables_double = instance_double GemGenerator::RenderVariables
+							# allow(render_variables_double).to receive(:find_config_file).and_return nil
+							# allow(render_variables_double).to receive(anything).and_call_original
+							#
+							# allow(GemGenerator::RenderVariables).to receive(:new)
+							#   .and_return render_variables_double
+
+							allow(Dir).to receive(:glob).and_call_original
+							allow(Dir).to(
+								receive(:glob)
+									.with(a_string_matching(%r{/\.gem_generator\.}), anything)
+									.and_return([])
+							)
+						end
+
+						context 'without namespace option' do
+							include_examples 'correct behavior without namespace'
+						end
+
+						context 'with namespace option' do
+							let(:namespace) { FFaker::Internet.user_name }
+							let(:args) do
+								[*super(), "--namespace=#{namespace}"]
+							end
+
+							context 'with author email from git' do
+								let(:author_email) do
+									FFaker::Internet.email
+								end
+
+								include_context 'with changing git user config', :email do
+									let(:temp_git_email) { author_email }
+								end
+
+								context 'with author name from git' do
+									let(:author_name) do
+										FFaker::Name.name
+									end
+
+									include_context 'with changing git user config', :name do
+										let(:temp_git_name) { author_name }
+									end
+
+									include_examples 'correct behavior with all data'
+
+									context 'with incorrect indentation option' do
+										let(:args) do
+											[*super(), '--indentation=foo']
+										end
+
+										specify do
+											expect { run }.to(
+												raise_error(SystemExit).and(
+													not_output.to_stdout.and(
+														output(<<~OUTPUT).to_stderr
+															ERROR: option '--indentation': Only `tabs` or `spaces` values acceptable
+
+															See: 'gem_generator --help'
+														OUTPUT
+													)
+												)
+											)
+										end
+									end
+								end
+
+								context 'without author name from git' do
+									include_examples 'correct behavior without author name'
+								end
+							end
+
+							context 'without author email from git' do
+								include_examples 'correct behavior without author email'
+							end
+						end
+					end
+
+					context 'with config file' do
+						around do |example|
+							raise "There is should not be `#{config_file_name}`!" if File.exist? config_file_name
+
+							File.write config_file_name, YAML.dump(config_file_content)
+							example.run
+						ensure
+							File.delete config_file_name
+						end
+
+						let(:config_file_content) { {} }
+
+						shared_examples 'correct behavior' do
+							shared_examples 'correct behavior with namespace' do
+								shared_examples 'correct behavior with author email' do
+									context 'with author name in config file' do
+										let(:config_file_content) do
+											super().deep_merge(author: { name: author_name })
+										end
+
+										let(:author_name) { FFaker::Name.name }
+
+										## It should be different and with lower priority
+										include_context 'with changing git user config', :name do
+											let(:temp_git_name) { FFaker::Name.name }
+										end
+
+										include_examples 'correct behavior with all data'
+									end
+
+									context 'without author name in config file' do
+										context 'with author name from git' do
+											let(:author_name) { FFaker::Name.name }
+
+											include_context 'with changing git user config', :name do
+												let(:temp_git_name) { author_name }
+											end
+
+											include_examples 'correct behavior with all data'
+										end
+
+										context 'without author name from git' do
+											include_examples 'correct behavior without author name'
+										end
+									end
+								end
+
+								let(:namespace) { FFaker::Internet.user_name }
+
+								context 'with author email in config file' do
+									let(:config_file_content) do
+										super().deep_merge(author: { email: author_email })
+									end
+
+									let(:author_email) { FFaker::Internet.email }
+
+									## It should be different and with lower priority
+									include_context 'with changing git user config', :email do
+										let(:temp_git_email) { FFaker::Internet.email }
+									end
+
+									include_examples 'correct behavior with author email'
+								end
+
+								context 'without author email in config file' do
+									context 'with author email from git' do
+										let(:author_email) { FFaker::Internet.email }
+
+										include_context 'with changing git user config', :email do
+											let(:temp_git_email) { author_email }
+										end
+
+										include_examples 'correct behavior with author email'
+									end
+
+									context 'without author email from git' do
+										include_examples 'correct behavior without author email'
+									end
+								end
+							end
+
+							context 'without namespace inside' do
+								context 'without namespace option' do
+									include_examples 'correct behavior without namespace'
+								end
+
+								context 'with namespace option' do
+									let(:args) do
+										[*super(), "--namespace=#{namespace}"]
+									end
+
+									include_examples 'correct behavior with namespace'
+								end
+							end
+
+							context 'with namespace inside' do
+								let(:config_file_content) do
+									super().deep_merge(namespace: config_namespace)
+								end
+
+								let(:config_namespace) { namespace }
+								let(:namespace) { FFaker::Internet.user_name }
+
+								context 'without namespace option' do
+									include_examples 'correct behavior with namespace'
+								end
+
+								context 'with namespace option' do
+									let(:config_namespace) { FFaker::Internet.user_name }
+
+									let(:args) do
+										[*super(), "--namespace=#{namespace}"]
+									end
+
+									include_examples 'correct behavior with namespace'
+								end
+							end
+						end
+
+						context 'when file extension is `.yaml`' do
+							let(:config_file_name) { '.gem_generator.yaml' }
+
+							include_examples 'correct behavior'
+						end
+
+						context 'when file extension is `.yml`' do
+							let(:config_file_name) { '.gem_generator.yml' }
+
+							include_examples 'correct behavior'
+						end
+					end
+				end
+
+				context 'when this template is local (by default)' do
+					let(:template) { "#{__dir__}/../support/example_template" }
+
+					shared_examples 'correct system calls with all data' do
+						include_examples 'common correct system calls with all data'
+
+						context 'without `package.json` file' do
+							specify do
+								expect(command_instance).not_to have_received(:system).with('npm install')
+							end
+						end
+
+						context 'with `package.json` file' do
+							around do |example|
+								if File.exist? "#{template}/package.json"
+									raise 'Template should not contain `package.json` file'
+								end
+
+								FileUtils.touch "#{template}/package.json"
+								example.run
+								FileUtils.rm "#{template}/package.json"
+							end
+
+							specify do
+								expect(command_instance).to have_received(:system).with('npm install').once
+							end
+						end
+					end
+
+					shared_examples 'correct files with all data' do
+						include_examples 'common correct files with all data'
 
 						describe 'bin/console.erb' do
 							describe 'permissions' do
@@ -360,348 +723,31 @@ describe GemGenerator::Command do
 							end
 						end
 					end
+
+					shared_examples 'correct behavior with all data' do
+						include_examples 'common correct behavior with all data'
+					end
+
+					include_examples 'correct behavior with template'
 				end
 
-				shared_examples 'correct behavior without author name' do
-					include_context 'with changing git user config', :name do
-						let(:temp_git_name) { nil }
+				context 'with `--git` option (for template)' do
+					let(:template) { 'AlexWayfer/gem_template' }
+					let(:args) { [*super(), '--git'] }
+
+					shared_examples 'correct system calls with all data' do
+						include_examples 'common correct system calls with all data'
 					end
 
-					describe 'output' do
-						let(:expected_output_start) do
-							## There is allowed prompt
-							<<~OUTPUT
-								Please, write a summary for the gem:
-
-								Thank you! You can write more detailed description later for `spec.description` and `README.md`.
-
-								Copying files...
-								Renaming files...
-							OUTPUT
-						end
-
-						## There is some dependencies installation output
-
-						let(:non_expected_output_end) do
-							<<~OUTPUT
-								Done.
-								To checkout into a new directory:
-									cd #{gem_name}
-							OUTPUT
-						end
-
-						specify do
-							expect { run }.to raise_error(SystemExit).and output(
-								a_string_starting_with(expected_output_start)
-									.and(not_ending_with(non_expected_output_end))
-							).to_stdout.and output(<<~OUTPUT).to_stderr
-								You have to specify project's author name.
-								You can use `git config user.name "My Name"`, or create a configuration file.
-								Check the README.
-							OUTPUT
-						end
+					shared_examples 'correct files with all data' do
+						include_examples 'common correct files with all data'
 					end
 
-					include_examples 'target directory does not exist'
-				end
-
-				shared_examples 'correct behavior without author email' do
-					include_context 'with changing git user config', :email do
-						let(:temp_git_email) { nil }
+					shared_examples 'correct behavior with all data' do
+						include_examples 'common correct behavior with all data'
 					end
 
-					context 'with author name from git' do
-						include_context 'with changing git user config', :name do
-							let(:temp_git_name) { FFaker::Name.name }
-						end
-
-						describe 'output' do
-							let(:expected_output_start) do
-								## There is allowed prompt
-								<<~OUTPUT
-									Please, write a summary for the gem:
-
-									Thank you! You can write more detailed description later for `spec.description` and `README.md`.
-
-									Copying files...
-									Renaming files...
-								OUTPUT
-							end
-
-							## There is some dependencies installation output
-
-							let(:non_expected_output_end) do
-								<<~OUTPUT
-									Done.
-									To checkout into a new directory:
-										cd #{gem_name}
-								OUTPUT
-							end
-
-							specify do
-								expect { run }.to raise_error(SystemExit).and output(
-									a_string_starting_with(expected_output_start)
-										.and(not_ending_with(non_expected_output_end))
-								).to_stdout.and output(<<~OUTPUT).to_stderr
-									You have to specify project's author email.
-									You can use `git config user.email "my.email@example.com"`, or create a configuration file.
-									Check the README.
-								OUTPUT
-							end
-						end
-
-						include_examples 'target directory does not exist'
-					end
-				end
-
-				shared_examples 'correct behavior without namespace' do
-					describe 'output' do
-						let(:expected_output_start) do
-							## There is allowed prompt
-							<<~OUTPUT
-								Please, write a summary for the gem:
-
-								Thank you! You can write more detailed description later for `spec.description` and `README.md`.
-
-								Copying files...
-								Renaming files...
-								Rendering files...
-							OUTPUT
-						end
-
-						## There is some dependencies installation output
-
-						let(:non_expected_output_end) do
-							<<~OUTPUT
-								Done.
-								To checkout into a new directory:
-									cd #{gem_name}
-							OUTPUT
-						end
-
-						specify do
-							expect { run }.to raise_error(SystemExit).and output(
-								a_string_starting_with(expected_output_start)
-									.and(not_ending_with(non_expected_output_end))
-							).to_stdout.and output(<<~OUTPUT).to_stderr
-								You have to specify project's namespace on GitHub.
-								You can use `--namespace` option, or create a configuration file.
-								Check the README.
-							OUTPUT
-						end
-					end
-
-					include_examples 'target directory does not exist'
-				end
-
-				context 'without config file' do
-					before do
-						# render_variables_double = instance_double GemGenerator::RenderVariables
-						# allow(render_variables_double).to receive(:find_config_file).and_return nil
-						# allow(render_variables_double).to receive(anything).and_call_original
-						#
-						# allow(GemGenerator::RenderVariables).to receive(:new)
-						#   .and_return render_variables_double
-
-						allow(Dir).to receive(:glob).and_call_original
-						allow(Dir).to(
-							receive(:glob)
-								.with(a_string_matching(%r{/\.gem_generator\.}), anything)
-								.and_return([])
-						)
-					end
-
-					context 'without namespace option' do
-						include_examples 'correct behavior without namespace'
-					end
-
-					context 'with namespace option' do
-						let(:namespace) { FFaker::Internet.user_name }
-						let(:args) do
-							[*super(), "--namespace=#{namespace}"]
-						end
-
-						context 'with author email from git' do
-							let(:author_email) do
-								FFaker::Internet.email
-							end
-
-							include_context 'with changing git user config', :email do
-								let(:temp_git_email) { author_email }
-							end
-
-							context 'with author name from git' do
-								let(:author_name) do
-									FFaker::Name.name
-								end
-
-								include_context 'with changing git user config', :name do
-									let(:temp_git_name) { author_name }
-								end
-
-								include_examples 'correct behavior with all data'
-
-								context 'with incorrect indentation option' do
-									let(:args) do
-										[*super(), '--indentation=foo']
-									end
-
-									specify do
-										expect { run }.to(
-											raise_error(SystemExit).and(
-												not_output.to_stdout.and(
-													output(<<~OUTPUT).to_stderr
-														ERROR: option '--indentation': Only `tabs` or `spaces` values acceptable
-
-														See: 'gem_generator --help'
-													OUTPUT
-												)
-											)
-										)
-									end
-								end
-							end
-
-							context 'without author name from git' do
-								include_examples 'correct behavior without author name'
-							end
-						end
-
-						context 'without author email from git' do
-							include_examples 'correct behavior without author email'
-						end
-					end
-				end
-
-				context 'with config file' do
-					around do |example|
-						raise "There is should not be `#{config_file_name}`!" if File.exist? config_file_name
-
-						File.write config_file_name, YAML.dump(config_file_content)
-						example.run
-						File.delete config_file_name
-					end
-
-					let(:config_file_content) { {} }
-
-					shared_examples 'correct behavior' do
-						shared_examples 'correct behavior with namespace' do
-							shared_examples 'correct behavior with author email' do
-								context 'with author name in config file' do
-									let(:config_file_content) do
-										super().deep_merge(author: { name: author_name })
-									end
-
-									let(:author_name) { FFaker::Name.name }
-
-									## It should be different and with lower priority
-									include_context 'with changing git user config', :name do
-										let(:temp_git_name) { FFaker::Name.name }
-									end
-
-									include_examples 'correct behavior with all data'
-								end
-
-								context 'without author name in config file' do
-									context 'with author name from git' do
-										let(:author_name) { FFaker::Name.name }
-
-										include_context 'with changing git user config', :name do
-											let(:temp_git_name) { author_name }
-										end
-
-										include_examples 'correct behavior with all data'
-									end
-
-									context 'without author name from git' do
-										include_examples 'correct behavior without author name'
-									end
-								end
-							end
-
-							let(:namespace) { FFaker::Internet.user_name }
-
-							context 'with author email in config file' do
-								let(:config_file_content) do
-									super().deep_merge(author: { email: author_email })
-								end
-
-								let(:author_email) { FFaker::Internet.email }
-
-								## It should be different and with lower priority
-								include_context 'with changing git user config', :email do
-									let(:temp_git_email) { FFaker::Internet.email }
-								end
-
-								include_examples 'correct behavior with author email'
-							end
-
-							context 'without author email in config file' do
-								context 'with author email from git' do
-									let(:author_email) { FFaker::Internet.email }
-
-									include_context 'with changing git user config', :email do
-										let(:temp_git_email) { author_email }
-									end
-
-									include_examples 'correct behavior with author email'
-								end
-
-								context 'without author email from git' do
-									include_examples 'correct behavior without author email'
-								end
-							end
-						end
-
-						context 'without namespace inside' do
-							context 'without namespace option' do
-								include_examples 'correct behavior without namespace'
-							end
-
-							context 'with namespace option' do
-								let(:args) do
-									[*super(), "--namespace=#{namespace}"]
-								end
-
-								include_examples 'correct behavior with namespace'
-							end
-						end
-
-						context 'with namespace inside' do
-							let(:config_file_content) do
-								super().deep_merge(namespace: config_namespace)
-							end
-
-							let(:config_namespace) { namespace }
-							let(:namespace) { FFaker::Internet.user_name }
-
-							context 'without namespace option' do
-								include_examples 'correct behavior with namespace'
-							end
-
-							context 'with namespace option' do
-								let(:config_namespace) { FFaker::Internet.user_name }
-
-								let(:args) do
-									[*super(), "--namespace=#{namespace}"]
-								end
-
-								include_examples 'correct behavior with namespace'
-							end
-						end
-					end
-
-					context 'when file extension is `.yaml`' do
-						let(:config_file_name) { '.gem_generator.yaml' }
-
-						include_examples 'correct behavior'
-					end
-
-					context 'when file extension is `.yml`' do
-						let(:config_file_name) { '.gem_generator.yml' }
-
-						include_examples 'correct behavior'
-					end
+					include_examples 'correct behavior with template'
 				end
 			end
 		end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,8 +25,10 @@ RSpec::Matchers.define :include_lines do |expected_lines|
 	diffable
 end
 
-RSpec::Matchers.define_negated_matcher :not_include_lines, :include_lines
 RSpec::Matchers.define_negated_matcher :not_ending_with, :ending_with
+RSpec::Matchers.define_negated_matcher :not_include, :include
+RSpec::Matchers.define_negated_matcher :not_include_lines, :include_lines
+RSpec::Matchers.define_negated_matcher :not_match, :match
 RSpec::Matchers.define_negated_matcher :not_output, :output
 
 require_relative '../lib/gem_generator/command'

--- a/spec/support/example_template/CHANGELOG.md
+++ b/spec/support/example_template/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
 
-## main (unreleased)
+## Unreleased
 
 *   Initial release.


### PR DESCRIPTION
It allows you to use `TEMPLATE` parameter as GitHub path
to automatically clone the repo (into `/tmp` directory)
and use its nested `template/` directory as a template.